### PR TITLE
shorten status bar text and add tooltip for full text

### DIFF
--- a/content/nostalgy.js
+++ b/content/nostalgy.js
@@ -274,9 +274,17 @@ function NostalgyHide(restore) {
 
 function NostalgyDefLabel() {
  nostalgy_gsuggest_folder = NostalgySuggest();
+
  if (nostalgy_gsuggest_folder) {
+   nostalgy_folder_name=NostalgyFolderName(nostalgy_gsuggest_folder);
+   nostalgy_label.setAttribute("tooltiptext"," [+Shift: ==> " + nostalgy_folder_name + "]");
+   folder_parts=nostalgy_folder_name.split("/");
+   if (folder_parts.length > 2) {
+     nostalgy_folder_name =  folder_parts[0] + ".." + folder_parts[folder_parts.length - 1];
+   }
+
    nostalgy_label.value =
-       nostalgy_default_label + " [+Shift: ==> " + NostalgyFolderName(nostalgy_gsuggest_folder) + "]";
+       nostalgy_default_label + " [+Shift:=>" + nostalgy_folder_name  + "]";
  } else {
    nostalgy_label.value = nostalgy_default_label;
  }


### PR DESCRIPTION
For long account names and nested folders, the status bar text can get so long, that in order to contain it, the whole Thunderbird window is made wider than the monitor.
This merge requests shortens the status bar text to the account name and last folder name in the path if the path contains nested folders. 
Additionally, it adds the full path as a tooltip to the status bar text.