### PR TITLE
nsIPrefBranch2 is removed in Gecko 57

### DIFF
--- a/content/nostalgy.js
+++ b/content/nostalgy.js
@@ -42,7 +42,7 @@ var NostalgyRules =
   {
     this._branch = NostalgyPrefService().getBranch("extensions.nostalgy.");
     this._branch2 =
-        this._branch.QueryInterface(Components.interfaces.nsIPrefBranch2);
+        this._branch.QueryInterface(Components.interfaces.nsIPrefBranch);
     this._branch2.addObserver("", this, false);
     this.get_rules();
 


### PR DESCRIPTION
Functionality addObserver has been under nsIPrefBranch for a while now.
I don't use all of nostalgy's functionality, but this small change makes it work for me again in TB57+