### PR TITLE
issue #60 focus fix and disable force popup open

### DIFF
--- a/content/folders.js
+++ b/content/folders.js
@@ -184,7 +184,7 @@ function NostalgyGetAutoCompleteValuesFunction(box) {
      * cancelled with Escape.  We thus force the popup to be opened some time after
      * the completion is done.
      */
-    if (box.popup.state == "closed" && nb != 0)
+    if (false && box.popup.state == "closed" && nb != 0)
       setTimeout(function() {
                    if (box.popup.state == "closed") {
                      NostalgyDebug("Forcing popup to be opened");

--- a/content/nostalgy.js
+++ b/content/nostalgy.js
@@ -266,7 +266,14 @@ function NostalgyHide(restore) {
  nostalgy_th_statusBar.hidden = nostalgy_th_statusBar_orig_hidden;
 
  if (nostalgy_focus_saved) {
-  if (restore) nostalgy_focus_saved.focus ();
+  if (restore) {
+    if (nostalgy_folderBox != nostalgy_focus_saved) {
+      console.log("setting focus");
+      console.log(nostalgy_focus_saved);
+      var _nfs = nostalgy_focus_saved;
+      setTimeout(function() {_nfs.focus();}, 0);
+    }
+  }
   nostalgy_focus_saved = null;
  }
  NostalgyDefLabel();


### PR DESCRIPTION
ESC will trigger ```<textbox id="nostalgy-folderbox" .... ontextreverted="NostalgyHide(true);"...``` which will call NostalgyHide(true); and looks like changing focus during TB tear-down of folderbox popUp will leave popUp in broken state.  I just added a timeout 0 do defer focus change after the tear-down. I have also disabled force popup open as this did not work for me - popup was not functional. 