### PR TITLE
Add usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ folder view.
 Installation
 ============
 
-The easiest way to install Thunderbird is through  Thunderbird`s addon page. It
+The easiest way to install Thunderbird is through  Thunderbird's addon page. It
 will automatically update itself when new versions are released.
 
 You can also try the latest development versions from https://github.com/nostalgy/nostalgy
@@ -40,8 +40,9 @@ Usage
 =======
 
 See
-- [markdown version](chrome/content/about.md) created via pandoc from the
-- [html version](chrome/content/about.xhtml)
+- [markdown version of usage](chrome/content/about.md)
+ created via pandoc from the
+- [html version of usage](chrome/content/about.xhtml)
 
 
 Authors

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Note: to produce an .xpi file from a git clone:
     git archive --format=zip --output nostalgy.zip HEAD
 
 
+Usage
+=======
+
+See
+- [markdown version](chrome/content/about.md) created via pandoc from the
+- [html version](chrome/content/about.xtml)
+
+
 Authors
 =======
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage
 
 See
 - [markdown version](chrome/content/about.md) created via pandoc from the
-- [html version](chrome/content/about.xtml)
+- [html version](chrome/content/about.xhtml)
 
 
 Authors

--- a/chrome/content/about.md
+++ b/chrome/content/about.md
@@ -20,24 +20,23 @@ The following shortcuts are available from the main Thunderbird\'s
 window. As a remainder and a sign of Nostalgy\'s presence, these
 shortcuts are displayed in Thunderbird\'s status bar.
 
-  Shortcut   Description
-  ---------- ------------------------------------------------------------
-  g          Open a specific folder
-  s          Move the current message to a specific folder
-  b          Move the current message to a specific folder and go there
-  c          Copy the current message to a specific folder
+- Shortcut   Description
+- `g` Open a specific folder
+- `s` Move the current message to a specific folder
+- `b` Move the current message to a specific folder and go there
+- `c` Copy the current message to a specific folder
 
 These commands open an folder completion box (in place of the status
 bar) where you can select a folder by typing part of its name. A popup
 displays the possible completions. Regular expressions are accepted as
-well (and .. is a short-hand for .\* meaning: any sequence of
+well (and `..` is a short-hand for `.*` meaning: any sequence of
 characters). You can choose the first suggested completion with RETURN,
 or select another one in the popup with the UP/DOWN keys and then
 RETURN. You can cancel the command with ESCAPE.
 
 Before you type anything in the folder completion box, the popup can
 display the most recently selected folders. You can choose one of them
-with the UP/DOWN keys. Due to recent chnanges in TB, you need to press
+with the UP/DOWN keys. Due to recent changes in TB, you need to press
 back arrow followed by up arrow to populate this box with the history.
 
 In the folder completion box, the TAB key activates a shell-like
@@ -51,28 +50,28 @@ fragment. (currently not working in TB68 - may be updated)
 It is possible to restrict (see the preference dialog) the completion to
 the folders on the same server as the currently displayed folder.
 
-The s,b,c commands can be applied to one or many messages.
+The `s`,`b`,`c` commands can be applied to one or many messages.
 
-The s and c commands also work in a standalone message window.
+The `s` and `c` commands also work in a standalone message window.
 
-The g command also focuses the thread pane. If you were doing a
+The `g` command also focuses the thread pane. If you were doing a
 QuickSearch (that is, if you had typed some text in the search box), the
 same search carried over to the new folder.
 
-The b command preserves the selection. The moved messages will be
+The `b` command preserves the selection. The moved messages will be
 selected again in the target folder.
 
 ### Custom shortcuts
 
 In the preference dialog, you can define any number of custom keyboard
-shortcuts. A custom shortcut triggers a g, s, c or b command to a
+shortcuts. A custom shortcut triggers a `g`, `s`, `c` or `b` command to a
 specific folder.
 
 ### 3-pane navigation
 
 Because of the g command, the folder pane becomes thus much less useful,
 and it can be hidden with the l shortcut. (Thunderbird already proposes
-a shortcut to show/hide the message pane: F8).
+a shortcut to show/hide the message pane: `F8`).
 
 Nostalgy also allows you to scroll the message while the thread pane is
 focused with the Ctrl-Left/Right or Shift-Left/Right keys. Because of
@@ -80,14 +79,13 @@ that, it is a good idea to leave the thread pane always focused.
 Nostalgy still provides shortcuts to easily focus one of the three
 panes.
 
-  Shortcut          Description
-  ----------------- ------------------------------------------------------------------------
-  l                 Hide/show the folder pane
-  ESC-f             Focus the folder pane
-  ESC-m             Focus the message pane
-  ESC-ESC           Focus the thread pane
-  ESC-ESC-ESC       Focus the thread pane, clear quick search box, select the \"All\" view
-  Ctrl-Left/Right   Scroll the message from the thread pane
+- Shortcut          Description
+- `l`                 Hide/show the folder pane
+- `ESC-f`             Focus the folder pane
+- `ESC-m`             Focus the message pane
+- `ESC-ESC`           Focus the thread pane
+- `ESC-ESC-ESC`       Focus the thread pane, clear quick search box, select the \"All\" view
+- `Ctrl-Left/Right`   Scroll the message from the thread pane
 
 ### Rules
 
@@ -96,8 +94,8 @@ message by looking for a substring of the From, To/Cc, or Subject
 headers (or a combination of them). A rule can be restricted to match
 messages only under a given server/folder. When a rule selects a folder
 for a given message, Nostalgy informs you in the status line. You can
-then use the Shift-S/Shift-C/Shift-G/Shift-B shortcuts to move/copy/go
-directly to this folder. Nostalgy\'s rules can be edited from the
+then use the `Shift-S/Shift-C/Shift-G/Shift-B` shortcuts to move/copy/go
+directly to this folder. Nostalgy's rules can be edited from the
 preference dialog.
 
 It is possible to match fields with a regexp instead of simply looking
@@ -132,7 +130,7 @@ done on the first recipient (To: header) instead of the sender.
 ### Tags
 
 Starting from version 2.0, Thunderbird supports tags, along with
-traditional folders, as a way to organize your messages. Thunderbird\'s
+traditional folders, as a way to organize your messages. Thunderbird's
 tagging feature replaces its former labeling feature, and allows users
 to define an unlimited number of tags, more than one of which can be
 attached to a single message.
@@ -144,9 +142,9 @@ existing tags, prefixed with a semi-colon.
 
 This needs to be enabled in settings
 
-A \"Go\" command applied to a tag restricts the current folder view to
-show only the messages that have this tag (ESC-ESC-ESC restores the
-\"All messages\" view). A \"Save\" or a \"Copy\" command applied to a
+A `Go` command applied to a tag restricts the current folder view to
+show only the messages that have this tag (`ESC-ESC-ESC` restores the
+"All messages" view). A "Save" or a "Copy" command applied to a
 tag toggles the tag on or off for the selected messages (the first
 selected message is used to determine if the tag has to be added or
 removed). Note that Save and Copy have the same behavior when applied to
@@ -159,15 +157,13 @@ creation dialog with the tag name set to `foobar` (in order to confirm
 the creation of the tag and choose its color). If you confirm, the
 command is applied to the new tag.
 
-You may also use tags rather than folders as targets for Nostalgy\'s
-rules.
+You may also use tags rather than folders as targets for Nostalgy's rules.
 
 ### In the Composer
 
-Nostalgy adds some support for keyboard operations to the Composer
-window.
+Nostalgy adds some support for keyboard operations to the Composer window.
 
-When typing in a header, it\'s possible to change easily the header to
+When typing in a header, it's possible to change easily the header to
 either \"To:\", \"Cc:\" or \"Bcc:\". To do so, you need to be at the
 beginning of the input box, and simply type \"to \", \"cc \" or \"bcc \"
 (with the whitespace, without the quotes).

--- a/chrome/content/about.md
+++ b/chrome/content/about.md
@@ -1,0 +1,214 @@
+Usage directions for Nostalgy
+-----------------------------
+
+Nostalgy adds several keyboard shortcuts to improve your productivity
+with Thunderbird. A custom preference dialog for Nostalgy is available
+through the Tools menu.
+
+**Notes about shortcuts:**
+
+-   We give here the default values for shortcuts. Most of them can be
+    changed from the preference dialog.
+-   Even if the key shortcuts are written in uppercase, you must not
+    press Shift (= use lowercase letters on keyboard).
+-   The ESC-X shortcuts means: press and release ESCAPE, and then press
+    X within 300ms (ESC-ESC is thus like a double click on ESCAPE).
+
+### Folder commands
+
+The following shortcuts are available from the main Thunderbird\'s
+window. As a remainder and a sign of Nostalgy\'s presence, these
+shortcuts are displayed in Thunderbird\'s status bar.
+
+  Shortcut   Description
+  ---------- ------------------------------------------------------------
+  g          Open a specific folder
+  s          Move the current message to a specific folder
+  b          Move the current message to a specific folder and go there
+  c          Copy the current message to a specific folder
+
+These commands open an folder completion box (in place of the status
+bar) where you can select a folder by typing part of its name. A popup
+displays the possible completions. Regular expressions are accepted as
+well (and .. is a short-hand for .\* meaning: any sequence of
+characters). You can choose the first suggested completion with RETURN,
+or select another one in the popup with the UP/DOWN keys and then
+RETURN. You can cancel the command with ESCAPE.
+
+Before you type anything in the folder completion box, the popup can
+display the most recently selected folders. You can choose one of them
+with the UP/DOWN keys. Due to recent chnanges in TB, you need to press
+back arrow followed by up arrow to populate this box with the history.
+
+In the folder completion box, the TAB key activates a shell-like
+autocompletion mode (this feature must be enabled in Nostalgy's
+preference dialog; otherwise, TAB cycles through the possible
+completions). In this mode, the completed suggestions only mentions
+possible completions one level down in the folder hierarchy, and the TAB
+key itself automatically completes with the longest unambiguous
+fragment. (currently not working in TB68 - may be updated)
+
+It is possible to restrict (see the preference dialog) the completion to
+the folders on the same server as the currently displayed folder.
+
+The s,b,c commands can be applied to one or many messages.
+
+The s and c commands also work in a standalone message window.
+
+The g command also focuses the thread pane. If you were doing a
+QuickSearch (that is, if you had typed some text in the search box), the
+same search carried over to the new folder.
+
+The b command preserves the selection. The moved messages will be
+selected again in the target folder.
+
+### Custom shortcuts
+
+In the preference dialog, you can define any number of custom keyboard
+shortcuts. A custom shortcut triggers a g, s, c or b command to a
+specific folder.
+
+### 3-pane navigation
+
+Because of the g command, the folder pane becomes thus much less useful,
+and it can be hidden with the l shortcut. (Thunderbird already proposes
+a shortcut to show/hide the message pane: F8).
+
+Nostalgy also allows you to scroll the message while the thread pane is
+focused with the Ctrl-Left/Right or Shift-Left/Right keys. Because of
+that, it is a good idea to leave the thread pane always focused.
+Nostalgy still provides shortcuts to easily focus one of the three
+panes.
+
+  Shortcut          Description
+  ----------------- ------------------------------------------------------------------------
+  l                 Hide/show the folder pane
+  ESC-f             Focus the folder pane
+  ESC-m             Focus the message pane
+  ESC-ESC           Focus the thread pane
+  ESC-ESC-ESC       Focus the thread pane, clear quick search box, select the \"All\" view
+  Ctrl-Left/Right   Scroll the message from the thread pane
+
+### Rules
+
+Nostalgy introduces a notion of rule. A rule associates a folder to a
+message by looking for a substring of the From, To/Cc, or Subject
+headers (or a combination of them). A rule can be restricted to match
+messages only under a given server/folder. When a rule selects a folder
+for a given message, Nostalgy informs you in the status line. You can
+then use the Shift-S/Shift-C/Shift-G/Shift-B shortcuts to move/copy/go
+directly to this folder. Nostalgy\'s rules can be edited from the
+preference dialog.
+
+It is possible to match fields with a regexp instead of simply looking
+for a substring. This is done by enclosing the corresponding field with
+slashes. E.g. `/^me@domain\.com$/` will match the field for an exact
+value (not a substring).
+
+When no rule apply to a given message, Nostalgy proposes to re-use (with
+Shift-S/Shift-C/Shift-G/Shift-B) the same folder as for the last
+operation. If the folder lookup has been restricted to the current
+server (in the Nostalgy preference dialog), then the last operation
+folder is attached to the current server. Otherwise, it is global.
+
+### Exporting and importing rules
+
+Nostalgy can import/export rules. This feature can be used as a backup
+mechanism, or to exchange rules between various computer or Thunderbird
+profiles.
+
+**IMPORTANT:** importing rules will destroy your current rules. Use this
+feature with caution.
+
+### Looking for messages with same sender / subject
+
+The key \"\`\" (backquote) launches a QuickSearch for messages from the
+same sender as the currently selected message. If you press the same key
+again, messages with the same subject are searched. And if you press
+again, the QuickSearch is cancelled. In the Sent folder, the search is
+done on the first recipient (To: header) instead of the sender.
+(Previous versions only, might be repaired for TB 72)
+
+### Tags
+
+Starting from version 2.0, Thunderbird supports tags, along with
+traditional folders, as a way to organize your messages. Thunderbird\'s
+tagging feature replaces its former labeling feature, and allows users
+to define an unlimited number of tags, more than one of which can be
+attached to a single message.
+
+Nostalgy helps you use tags in much the same way it helps you use
+folders: The completion box for the Go/Save/Copy commands has always
+listed your email folders, but for Thunderbird 2.0, it also lists your
+existing tags, prefixed with a semi-colon.
+
+This needs to be enabled in settings
+
+A \"Go\" command applied to a tag restricts the current folder view to
+show only the messages that have this tag (ESC-ESC-ESC restores the
+\"All messages\" view). A \"Save\" or a \"Copy\" command applied to a
+tag toggles the tag on or off for the selected messages (the first
+selected message is used to determine if the tag has to be added or
+removed). Note that Save and Copy have the same behavior when applied to
+tags.
+
+It is possible to create new tags directly from the completion box. If
+you enter a string of the form `:foobar` or `:foobar:` (that is, a
+leading colon and an optional trailing colon), it will open the tag
+creation dialog with the tag name set to `foobar` (in order to confirm
+the creation of the tag and choose its color). If you confirm, the
+command is applied to the new tag.
+
+You may also use tags rather than folders as targets for Nostalgy\'s
+rules.
+
+### In the Composer
+
+Nostalgy adds some support for keyboard operations to the Composer
+window.
+
+When typing in a header, it\'s possible to change easily the header to
+either \"To:\", \"Cc:\" or \"Bcc:\". To do so, you need to be at the
+beginning of the input box, and simply type \"to \", \"cc \" or \"bcc \"
+(with the whitespace, without the quotes).
+
+The ESC-ESC combination focuses the message body. The ESC-A combination
+opens the file attachment dialog.
+
+### Preferences
+
+The preference dialog for Nostalgy has several tabs. The first tab is
+the place where rules are defined. The second tab has several switches
+to control the way the completion box (where folder names are proposed)
+is populated (see below). The third pane allows you to configure
+Nostalgy\'s shortcuts (click on the key to change it), to disable some
+of them, or to manage custom shortcuts.
+
+Here is a description of the completion options:
+
+-   **Restrict folder completion to the current server:** limit lookup
+    to folders on the same server/account as the currently active
+    folder. In this mode, the server name is not displayed (and must not
+    be typed) in the input line and the completion box.
+-   **Match only on folder name, not on the full path:** force Nostalgy
+    to interpret differently what is typed in the text. Normally, when
+    the option is disabled, it is interpreted as a regexp which can
+    match an arbitrary substring of the complete folder name (including
+    the account name and the name of parent folders). When the option is
+    enabled, the regexp must match either a substring of the local
+    folder name (not the full name) or a prefix of the full folder name.
+-   **Sort folders alphabetically**.
+-   **Match folder names in a case sensitive way**.
+-   **Tab triggers shell-like completion (otherwise, cycle through
+    suggestions)**.
+-   **Always include tags**: if set, tags are always included in the
+    completion box; otherwise, tags are included only if the input box
+    starts with a colon character, or if no folder matches.
+
+### Utilities
+
+The restart button forces Thunderbird to restart. This may be useful for
+developers, when many windows need to be closed, or when addons have
+been deleted/reloaded etc.
+
+------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #68 by making a markdown version of the usage (`about.md`) and adds pointers to that and to the original html version in the README.
I used pandoc to convert about.xhtml to about.md and then did some manual editing of about.md.
The markdown version has the benefit of being directly viewable in github browser.
The main drawback of this PR is that the .md and .xhtml versions may get out of sync in the future.

BTW, I am a huge fan of nostalgy and I am still using TB60 because (if I recall) nostalgy did not work with TB68 when TB68 first came out.  It would be nice if the README would specify what is the current version of TB that is supported by nostalgy.